### PR TITLE
Updated LabelBinarizer and cross_val_predict

### DIFF
--- a/pyopls/permutation_test.py
+++ b/pyopls/permutation_test.py
@@ -314,7 +314,12 @@ def _permutation_test_score(estimator, X, y, groups=None, cv='warn',
     """Auxiliary function for permutation_test_score"""
     if score_functions is None:
         score_functions = [r2_score]
-    y_pred = cross_val_predict(estimator, X, y, groups, cv, n_jobs, verbose, fit_params, pre_dispatch, method)
+    try: 
+        y_pred = cross_val_predict(estimator, X, y, groups=groups, cv=cv, n_jobs=n_jobs, 
+                                verbose=verbose, fit_params=fit_params, pre_dispatch=pre_dispatch, method=method)
+    except TypeError:
+        y_pred = cross_val_predict(estimator, X, y, groups=groups, cv=cv, n_jobs=n_jobs, 
+                                verbose=verbose, params=fit_params, pre_dispatch=pre_dispatch, method=method)        
     cv_scores = [score_function(y, y_pred) for score_function in score_functions]
     return np.array(cv_scores)
 

--- a/pyopls/validation.py
+++ b/pyopls/validation.py
@@ -205,12 +205,12 @@ class OPLSValidator(BaseEstimator, TransformerMixin, RegressorMixin):
     def _validate(self, X, Y, n_components, score_function, cv=None, n_jobs=None, verbose=0, pre_dispatch='2*n_jobs'):
         cv = cv or self._get_validator(Y, self.k)
         Z = OPLS(n_components, self.scale).fit_transform(X, Y)
-        y_pred = cross_val_predict(PLSRegression(1, self.scale), Z, Y, cv=cv, n_jobs=n_jobs, verbose=verbose,
+        y_pred = cross_val_predict(PLSRegression(1, scale=self.scale), Z, Y, cv=cv, n_jobs=n_jobs, verbose=verbose,
                                    pre_dispatch=pre_dispatch)
         return score_function(Y, y_pred)
 
     def _process_binary_target(self, y, pos_label=None):
-        self.binarizer_ = LabelBinarizer(-1, 1)
+        self.binarizer_ = LabelBinarizer(neg_label=-1, pos_label=1)
         self.binarizer_.fit(y)
         if pos_label is not None and self.binarizer_.transform([pos_label])[0] == -1:
             self.binarizer_.classes_ = np.flip(self.binarizer_.classes_)
@@ -367,7 +367,7 @@ class OPLSValidator(BaseEstimator, TransformerMixin, RegressorMixin):
         """
         Z = OPLS(n_components, self.scale).fit_transform(X, y)
         x_loadings, permutation_x_loadings, p_values = feature_permutation_loading(
-            PLSRegression(1, self.scale), Z, y, self.n_inner_permutations, self.inner_alpha,
+            PLSRegression(1, scale=self.scale), Z, y, self.n_inner_permutations, self.inner_alpha,
             self.n_outer_permutations, random_state, n_jobs, verbose, pre_dispatch
         )
         return p_values < self.outer_alpha, p_values, permutation_x_loadings
@@ -376,7 +376,7 @@ class OPLSValidator(BaseEstimator, TransformerMixin, RegressorMixin):
         Z = self.opls_.transform(X)
         cv = cv or self._get_validator(y, self.k)
         check_is_fitted(self, ['opls_', 'pls_', 'binarizer_'])
-        y_pred = cross_val_predict(PLSRegression(1, self.scale), Z, y, cv=cv, n_jobs=n_jobs, verbose=verbose,
+        y_pred = cross_val_predict(PLSRegression(1, scale=self.scale), Z, y, cv=cv, n_jobs=n_jobs, verbose=verbose,
                                    pre_dispatch=pre_dispatch)
         return roc_curve(y, y_pred)
 
@@ -462,7 +462,7 @@ class OPLSValidator(BaseEstimator, TransformerMixin, RegressorMixin):
 
         self.opls_ = OPLS(self.n_components_, self.scale).fit(X, y)
         Z = self.opls_.transform(X)
-        self.pls_ = PLSRegression(1, self.scale).fit(Z, y)
+        self.pls_ = PLSRegression(1, scale=self.scale).fit(Z, y)
         self.r_squared_X_ = self.opls_.score(X)
         y_pred = self.pls_.predict(Z)
         self.r_squared_Y_ = r2_score(y, y_pred)
@@ -477,7 +477,7 @@ class OPLSValidator(BaseEstimator, TransformerMixin, RegressorMixin):
 
         _log('Performing cross-validated metric permutation tests.')
 
-        cv_results = permutation_test_score(PLSRegression(1, self.scale), Z, y, cv=cv,
+        cv_results = permutation_test_score(PLSRegression(1, scale=self.scale), Z, y, cv=cv,
                                             n_permutations=self.n_permutations, cv_score_functions=score_functions,
                                             n_jobs=n_jobs, verbose=verbose, pre_dispatch=pre_dispatch)
         if self.is_discrimination(y):


### PR DESCRIPTION
The arguments needed to be explicitly passed. Only other compatibility issue was cross_val_predict depreceated fit_params arg in 1.6, so uses params. I first try fit_params and use params if TypeError